### PR TITLE
Several bug fixes

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -17,10 +17,11 @@ class IncomingMessage
 
   # Executes incomming message.
   def execute
-    return if current_user && (current_user.bot? || (channel.standups.empty? && !start?))
+    return if current_user && (current_user.bot? || (channel.today_standups.empty? && !start?))
 
-    if start?
+    if start? && channel.today_standups.empty?
       start_standup
+
     elsif command
       command.execute
 

--- a/app/models/incoming_message/compound.rb
+++ b/app/models/incoming_message/compound.rb
@@ -7,6 +7,9 @@ class IncomingMessage
       super(message, standup)
 
       @standup = channel.today_standups.where(user_id: reffered_user.id).first!
+
+    rescue ActiveRecord::RecordNotFound
+      raise InvalidCommand.new("<@#{user.slack_id}> Given user is not participating of today standup.")
     end
 
     def user

--- a/app/models/incoming_message/postpone.rb
+++ b/app/models/incoming_message/postpone.rb
@@ -14,6 +14,8 @@ class IncomingMessage
     def validate!
       if !@standup.active?
         raise InvalidCommand.new("You can only skip the standup when asked.")
+      elsif channel.today_standups.pending.empty?
+        raise InvalidCommand.new("You can not skip your standup because you are the last one in the stack.")
       end
 
       super

--- a/app/models/incoming_message/skip.rb
+++ b/app/models/incoming_message/skip.rb
@@ -22,6 +22,8 @@ class IncomingMessage
         raise InvalidCommand.new("<@#{reffered_user.slack_id}> has already completed standup today.")
       elsif @standup.answering?
         raise InvalidCommand.new("<@#{reffered_user.slack_id}> is doing his/her standup.")
+      elsif channel.today_standups.pending.empty?
+        raise InvalidCommand.new("The standup can not be skipped because is the last one in the stack.")
       end
 
       super

--- a/app/models/incoming_message/status.rb
+++ b/app/models/incoming_message/status.rb
@@ -6,7 +6,7 @@ class IncomingMessage
     def execute
       super
 
-      message = @standup.channel.today_standups.map do |standup|
+      message = channel.today_standups.map do |standup|
         "#{standup.status}\n"
       end
 

--- a/lib/standupbot/client.rb
+++ b/lib/standupbot/client.rb
@@ -33,13 +33,19 @@ module Standupbot
         if channel.complete?
           channel.message('Today\'s standup is already completed.')
           realtime.stop!
+
+        elsif channel.today_standups.any?
+          channel.message('Standup is up again!!! Here you have the previous status of the standup:')
+
+          IncomingMessage::Status.new({}, channel.today_standups.first).execute
+
         else
           channel.message('Welcome to standup! Type "-Start" to get started.')
         end
       end
 
       realtime.on :message do |data|
-        if data['channel'] == channel.slack_id
+        if data['channel'] == channel.slack_id && data['text'].present?
           message = IncomingMessage.new(data)
 
           message.execute

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -152,8 +152,8 @@ describe IncomingMessage do
           expect { subject.execute }.to_not change { Standup.count }
         end
 
-        it 'creates a job to auto skip current user if needed' do
-          expect_any_instance_of(described_class::AutoSkip).to receive(:perform)
+        it 'does not create a job to auto skip current user if needed' do
+          expect_any_instance_of(described_class::AutoSkip).to_not receive(:perform)
 
           subject.execute
         end
@@ -201,8 +201,8 @@ describe IncomingMessage do
         context 'for an ACTIVE standup' do
           before { standup.update_attributes(state: Standup::ACTIVE, order: 1) }
 
-          it 'creates a job to auto skip current user if needed' do
-            expect_any_instance_of(described_class::AutoSkip).to receive(:perform)
+          it 'does not create a job to auto skip current user' do
+            expect_any_instance_of(described_class::AutoSkip).to_not receive(:perform)
 
             subject.execute
           end
@@ -211,6 +211,12 @@ describe IncomingMessage do
             let!(:standup_2) { create(:standup, state: Standup::IDLE, channel_id: channel.id, order: 2) }
 
             before { channel.users << standup_2.user }
+
+            it 'creates a job to auto skip current user if needed' do
+              expect_any_instance_of(described_class::AutoSkip).to receive(:perform)
+
+              subject.execute
+            end
 
             it 'changes its state to IDLE back' do
               expect { subject.execute }.to change { standup.reload.state }.to(Standup::IDLE)


### PR DESCRIPTION
The bot was crashing when someone edited a message.
Do not ask for the standup of a new user if there is another one in progress.
Prevent the skip action when there are no other users in the stack.