### PR TITLE
Let api endpoint through basic auth

### DIFF
--- a/app/middleware/app_auth.rb
+++ b/app/middleware/app_auth.rb
@@ -1,0 +1,12 @@
+class AppAuth < Rack::Auth::Basic
+
+  def call(env)
+    request = Rack::Request.new(env)
+
+    if request.path === '/api/standups/start'
+      @app.call(env)
+    else
+      super
+    end
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.middleware.insert_after(::Rack::Runtime, "::Rack::Auth::Basic", "Production") do |u, p|
+  config.middleware.insert_after(::Rack::Runtime, "AppAuth", "Production") do |u, p|
     [u, p] == [ENV['STANDUPBOT_USERNAME'], ENV['STANDUPBOT_SECRET']]
   end
 


### PR DESCRIPTION
Does not restrict `/api/standups/start` with basic auth. Allows slack `/standup` command to work again.